### PR TITLE
replace dependency buffertools with buffer-equal

### DIFF
--- a/filecompare.js
+++ b/filecompare.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var bt = require('buffertools');
+var bufferEqual = require('buffer-equal');
 
 /**
  * Compares two files by content using bufSize as buffer lenth.
@@ -30,7 +30,7 @@ var compareSync = function (path1, path2, bufSize, progressCallback) {
             if (read1 !== read2) {
                 return false;
             }
-            if (!bt.equals(buf1, buf2)) {
+            if (!bufferEqual(buf1, buf2)) {
                 return false;
             }
             len += read1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dir-compare",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Node JS directory compare",
     "main": "index.js",
     "repository": {
@@ -9,7 +9,7 @@
     },
     "keywords": ["compare", "directory", "folder"],
     "dependencies": {
-        "buffertools": "2.1.2",
+        "buffer-equal": "0.0.1",
         "colors": "1.0.3",
         "commander": "2.5.0",
         "minimatch": "2.0.1"


### PR DESCRIPTION
buffer-equal uses node 0.11+ buffer.equals when available, buffertools require compilation (problematic on windows)