### PR TITLE
- only return false cases to allow both include and exclude filters

### DIFF
--- a/common.js
+++ b/common.js
@@ -76,25 +76,19 @@ module.exports = {
 	 * Filter entries by file name. Returns true if the file is to be processed.
 	 */
 	filterEntry : function(entry, options){
-	    if(entry.symlink && options.skipSymlinks){
+	    if (entry.symlink && options.skipSymlinks){
 	        return false;
 	    }
 
-	    if(entry.stat.isFile() && options.includeFilter){
-	        if(this.match(entry.name, options.includeFilter)){
-	            return true;
-	        } else{
-	            return false;
-	        }
-	    }
-	    if(options.excludeFilter){
-	        if(this.match(entry.name, options.excludeFilter)){
-	            return false;
-	        } else{
-	            return true;
-	        }
-	    }
-	    return true;
+        if ((entry.stat.isFile() && options.includeFilter) && (!this.match(entry.name, options.includeFilter))) {
+            return false;
+        }
+
+        if ((options.excludeFilter) && (this.match(entry.name, options.excludeFilter))) {
+            return false;
+        }
+
+        return true;
 	},
 	/**
 	 * Comparator for directory entries sorting.


### PR DESCRIPTION
I would like to propose this change to the `includeFilter` and `excludeFilter` matching options.

As it stands now, `includeFilter` and `excludeFilter` cannot be used in conjunction with each other. If you have an `includeFilter` set, then it will return a `true` or `false` and never reach the `excludeFilter`. 

I feel like this logic should be improved so that both filters can be used. It makes it easier for cases like "only include pngs" but "exclude files matching `test*`". 

I can't see much downside to changing the logic. I ran your tests and had slightly different results, so I'll let you be the final judge.

Before Changes:

```
============== Coverage summary ==============
Statements   : 91.92% ( 569/619 )
Branches     : 87.87% ( 413/470 )
Functions    : 88.89% ( 64/72 )
Lines        : 92.21% ( 568/616 )
```

After Changes:

```
============== Coverage summary ==============
Statements   : 91.87% ( 565/615 )
Branches     : 87.85% ( 412/469 )
Functions    : 88.89% ( 64/72 )
Lines        : 92.16% ( 564/612 )
```

