### PR TITLE
Added type definitions for typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /node_modules/
 .project
+.vscode
 /tests/report.txt
 /tests/testdir
 /coverage/
 test*.js
+test*.js.map
+test*.ts

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ branches:
   only: master
 script:
   - npm install
+  - node_modules/typescript/bin/tsc -p tsconfig.json
   - node ./node_modules/istanbul/lib/cli.js cover tests/runTests.js
   - if ! [[ $(node --version) =~ v3.3.1|v0.11|v0.12 ]]; then codecov; else echo no codecov; fi;

--- a/README.md
+++ b/README.md
@@ -18,62 +18,57 @@ $ npm install dir-compare -g
 for command line utility.
 
 ## Library usage
-Synchronous mode:
+
 ```javascript
 var dircompare = require('dir-compare');
+var format = require('util').format;
+
 var options = {compareSize: true};
 var path1 = '...';
 var path2 = '...';
+
+var states = {'equal' : '==', 'left' : '->', 'right' : '<-', 'distinct' : '<>'};
+
+// Synchronous
 var res = dircompare.compareSync(path1, path2, options);
-console.log('equal: ' + res.equal);
-console.log('distinct: ' + res.distinct);
-console.log('left: ' + res.left);
-console.log('right: ' + res.right);
-console.log('differences: ' + res.differences);
-console.log('same: ' + res.same);
-var format = require('util').format;
+console.log(format('equal: %s, distinct: %s, left: %s, right: %s, differences: %s, same: %s',
+            res.equal, res.distinct, res.left, res.right, res.differences, res.same));
 res.diffSet.forEach(function (entry) {
-    var state = {
-        'equal' : '==',
-        'left' : '->',
-        'right' : '<-',
-        'distinct' : '<>'
-    }[entry.state];
+    var state = states[entry.state];
     var name1 = entry.name1 ? entry.name1 : '';
     var name2 = entry.name2 ? entry.name2 : '';
-
     console.log(format('%s(%s)%s%s(%s)', name1, entry.type1, state, name2, entry.type2));
 });
+
+// Asynchronous
+dircompare.compare(path1, path2, options)
+  .then(res => {
+      console.log(format('equal: %s, distinct: %s, left: %s, right: %s, differences: %s, same: %s',
+                  res.equal, res.distinct, res.left, res.right, res.differences, res.same));
+      res.diffSet.forEach(entry => {
+          var state = states[entry.state];
+          var name1 = entry.name1 ? entry.name1 : '';
+          var name2 = entry.name2 ? entry.name2 : '';
+
+          console.log(format('%s(%s)%s%s(%s)', name1, entry.type1, state, name2, entry.type2));
+      });
+  })
+  .catch(error => console.error(error));
 ```
-Asynchronous:
-```javascript
-var dircompare = require('dir-compare');
-var options = {compareSize: true};
+
+Typescript
+```typescript
+import { compare, compareSync, Options } from "dir-compare";
 var path1 = '...';
 var path2 = '...';
-dircompare.compare(path1, path2, options).then(function(res){
-    console.log('equal: ' + res.equal);
-    console.log('distinct: ' + res.distinct);
-    console.log('left: ' + res.left);
-    console.log('right: ' + res.right);
-    console.log('differences: ' + res.differences);
-    console.log('same: ' + res.same);
-    var format = require('util').format;
-    res.diffSet.forEach(function (entry) {
-        var state = {
-            'equal' : '==',
-            'left' : '->',
-            'right' : '<-',
-            'distinct' : '<>'
-        }[entry.state];
-        var name1 = entry.name1 ? entry.name1 : '';
-        var name2 = entry.name2 ? entry.name2 : '';
+var options: Partial<Options> = {compareSize: true};
 
-        console.log(format('%s(%s)%s%s(%s)', name1, entry.type1, state, name2, entry.type2));
-    });    
-}).catch(function(error){
-    console.error(error);
-})
+var res = compareSync(path1, path2, options);
+console.log(res)
+
+compare(path1, path2, options)
+  .then(res => console.log(res))
+  .catch(error => console.error(error));
 ```
 
 Options:
@@ -197,6 +192,7 @@ dircompare.compare(path1, path2, options)
 ```
 
 ## Changelog
+* v1.6.0 typescript support
 * v1.5.0 added option to ignore line endings and white space differences
 * v1.3.0 added date tolerance option
 * v1.2.0 added compare by date option

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,274 @@
+/// <reference types="node" />
+
+import * as fs from "fs";
+
+export function compareSync(path1: string, path2: string, options?: Partial<Options>): Statistics;
+export function compare(path1: string, path2: string, options?: Partial<Options>): Promise<Statistics>;
+
+export interface Options {
+    /**
+     * Compares files by size. Defaults to 'false'.
+     */
+    compareSize: boolean;
+
+    /**
+     *  Compares files by date of modification (stat.mtime). Defaults to 'false'.
+     */
+    compareDate: boolean;
+
+    /**
+     * Two files are considered to have the same date if the difference between their modification dates fits within date tolerance. Defaults to 1000 ms.
+     */
+    dateTolerance: number;
+
+    /**
+     *  Compares files by content. Defaults to 'false'.
+     */
+    compareContent: boolean;
+
+    /**
+     * Skips sub directories. Defaults to 'false'.
+     */
+    skipSubdirs: boolean;
+
+    /**
+     * Ignore symbolic links. Defaults to 'false'.
+     */
+    skipSymlinks: boolean;
+
+    /**
+     * Ignores case when comparing names. Defaults to 'false'.
+     */
+    ignoreCase: boolean;
+
+    /**
+     * Toggles presence of diffSet in output. If true, only statistics are provided. Use this when comparing large number of files to avoid out of memory situations. Defaults to 'false'.
+     */
+    noDiffSet: boolean;
+
+    /**
+     * File name filter. Comma separated minimatch patterns.
+     */
+    includeFilter: boolean;
+
+    /**
+     * File/directory name exclude filter. Comma separated minimatch patterns.
+     */
+    excludeFilter: boolean;
+
+    /**
+     * Callback for constructing result - function (entry1, entry2, state, level, relativePath, options, statistics, diffSet). Called for each compared entry pair. Updates 'statistics' and 'diffSet'.
+     */
+    resultBuilder: (
+        entry1: Entry | undefined,
+        entry2: Entry | undefined,
+        state: DifferenceState,
+        level: number,
+        relativePath: string,
+        options: Partial<Options>,
+        statistics: Statistics,
+        diffset: Array<Difference> | undefined
+    ) => Difference;
+
+    /**
+     * File comparison handler.
+     */
+    compareFileSync: CompareFileSync;
+
+    /**
+     * File comparison handler.
+     */
+    compareFileAsync: CompareFileAsync;
+}
+
+export interface Entry {
+    name: string;
+    absolutePath: string;
+    path: string;
+    stat: fs.Stats;
+    lstat: fs.Stats;
+    symlink: boolean;
+}
+
+export interface Statistics {
+    /**
+     * number of distinct entries.
+     */
+    distinct: number;
+
+    /**
+     * number of equal entries.
+     */
+    equal: number;
+
+    /**
+     * number of entries only in path1.
+     */
+    left: number;
+
+    /**
+     * number of entries only in path2.
+     */
+    right: number;
+
+    /**
+     * total number of differences (distinct+left+right).
+     */
+    differences: number;
+
+    /**
+     * number of distinct files.
+     */
+    distinctFiles: number;
+
+    /**
+     * number of equal files.
+     */
+    equalFiles: number;
+
+    /**
+     * number of files only in path1.
+     */
+    leftFiles: number;
+
+    /**
+     * number of files only in path2
+     */
+    rightFiles: number;
+
+    /**
+     * total number of different files (distinctFiles+leftFiles+rightFiles).
+     */
+    differencesFiles: number;
+
+    /**
+     * number of distinct directories.
+     */
+    distinctDirs: number;
+
+    /**
+     * number of equal directories.
+     */
+    equalDirs: number;
+
+    /**
+     * number of directories only in path1.
+     */
+    leftDirs: number;
+
+    /**
+     * number of directories only in path2.
+     */
+    rightDirs: number;
+
+    /**
+     * total number of different directories (distinctDirs+leftDirs+rightDirs).
+     */
+    differencesDirs: number;
+
+    /**
+     * true if directories are identical.
+     */
+    same: boolean;
+
+    /**
+     * List of changes (present if Options.noDiffSet is false).
+     */
+    diffSet?: Array<Difference>;
+}
+
+export type DifferenceState = "equal" | "left" | "right" | "distinct";
+export type DifferenceType = "missing" | "file" | "directory";
+export interface Difference {
+    /**
+     * path not including file/directory name; can be relative or absolute depending on call to compare().
+     */
+    path1: string;
+
+    /**
+     * path not including file/directory name; can be relative or absolute depending on call to compare().
+     */
+    path2: string;
+
+    /**
+     * path relative to root.
+     */
+    relativePath: string;
+
+    /**
+     * file/directory name.
+     */
+    name1: string;
+
+    /**
+     * file/directory name.
+     */
+    name2: string;
+
+    /**
+     * one of equal, left, right, distinct.
+     */
+    state: DifferenceState;
+
+    /**
+     * one of missing, file, directory.
+     */
+    type1: DifferenceType;
+
+    /**
+     * one of missing, file, directory.
+     */
+    type2: DifferenceType;
+
+    /**
+     * file size.
+     */
+    size1: number;
+
+    /**
+     * file size.
+     */
+    size2: number;
+
+    /**
+     * modification date (stat.mtime).
+     */
+    date1: number;
+
+    /**
+     * modification date (stat.mtime).
+     */
+    date2: number;
+
+    /**
+     * depth.
+     */
+    level: number;
+}
+
+export type CompareFileSync = (
+    path1: string,
+    stat1: fs.Stats,
+    path2: string,
+    stat2: fs.Stats,
+    options: Partial<Options>
+) => boolean;
+
+export type CompareFileAsync = (
+    path1: string,
+    stat1: fs.Stats,
+    path2: string,
+    stat2: fs.Stats,
+    options: Partial<Options>
+) => Promise<boolean>;
+
+export const fileCompareHandlers: {
+    defaultFileCompare: {
+        compareSync: CompareFileSync,
+        compareAsync: CompareFileAsync
+    },
+    lineBasedFileCompare: {
+        compareSync: CompareFileSync,
+        compareAsync: CompareFileAsync
+    }
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,8 @@
 
 import * as fs from "fs";
 
-export function compareSync(path1: string, path2: string, options?: Partial<Options>): Partial<Statistics>;
-export function compare(path1: string, path2: string, options?: Partial<Options>): Promise<Partial<Statistics>>;
+export function compareSync(path1: string, path2: string, options?: Partial<Options>): Statistics;
+export function compare(path1: string, path2: string, options?: Partial<Options>): Promise<Statistics>;
 
 export interface Options {
     /**
@@ -73,7 +73,7 @@ export interface Options {
         options: Partial<Options>,
         statistics: Statistics,
         diffset: Array<Difference> | undefined
-    ) => Difference;
+    ) => void;
 
     /**
      * File comparison handler.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,15 @@
 
 import * as fs from "fs";
 
-export function compareSync(path1: string, path2: string, options?: Partial<Options>): Statistics;
-export function compare(path1: string, path2: string, options?: Partial<Options>): Promise<Statistics>;
+export function compareSync(path1: string, path2: string, options?: Partial<Options>): Partial<Statistics>;
+export function compare(path1: string, path2: string, options?: Partial<Options>): Promise<Partial<Statistics>>;
 
 export interface Options {
+    /**
+     * Properties to be used in various extension points ie. result builder.
+     */
+    [key: string]: any
+
     /**
      * Compares files by size. Defaults to 'false'.
      */
@@ -49,12 +54,12 @@ export interface Options {
     /**
      * File name filter. Comma separated minimatch patterns.
      */
-    includeFilter: boolean;
+    includeFilter: string;
 
     /**
      * File/directory name exclude filter. Comma separated minimatch patterns.
      */
-    excludeFilter: boolean;
+    excludeFilter: string;
 
     /**
      * Callback for constructing result - function (entry1, entry2, state, level, relativePath, options, statistics, diffSet). Called for each compared entry pair. Updates 'statistics' and 'diffSet'.
@@ -91,6 +96,11 @@ export interface Entry {
 }
 
 export interface Statistics {
+    /**
+     * Any property is allowed if default result builder is not used.
+     */
+    [key: string]: any
+
     /**
      * number of distinct entries.
      */

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "dircompare": "dircompare.js"
     },
     "scripts": {
-        "pretest": "node_modules/typescript/bin/tsc -p tsconfig.json",
+        "pretest": "tsc -p tsconfig.json",
         "test": "istanbul cover tests/runTests.js"
     },
     "author": "Liviu Grigorescu",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
         "semver": "5.6.0",
         "shelljs": "0.3.0",
         "tar-fs": "1.13.0",
-        "temp": "0.8.1"
+        "temp": "0.8.1",
+        "typescript": "3.2.2"
     },
     "bin": {
         "dircompare": "dircompare.js"
     },
     "scripts": {
+        "pretest": "node_modules/typescript/bin/tsc -p tsconfig.json",
         "test": "istanbul cover tests/runTests.js"
     },
     "author": "Liviu Grigorescu",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,18 @@
     "version": "1.5.4",
     "description": "Node JS directory compare",
     "main": "index.js",
+    "types": "index.d.ts",
     "repository": {
         "type": "git",
         "url": "https://github.com/gliviu/dir-compare"
     },
-    "keywords": ["compare", "directory", "folder"],
+    "keywords": [
+        "compare",
+        "directory",
+        "folder"
+    ],
     "dependencies": {
+        "@types/node": "^10.12.18",
         "buffer-equal": "1.0.0",
         "colors": "1.0.3",
         "commander": "2.9.0",
@@ -16,12 +22,12 @@
         "bluebird": "3.4.1"
     },
     "devDependencies": {
-        "shelljs": "0.3.0",
-        "tar-fs": "1.13.0",
-        "temp": "0.8.1",
         "istanbul": "0.4.5",
         "memory-streams": "0.1.0",
-        "semver": "5.6.0"
+        "semver": "5.6.0",
+        "shelljs": "0.3.0",
+        "tar-fs": "1.13.0",
+        "temp": "0.8.1"
     },
     "bin": {
         "dircompare": "dircompare.js"

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+runTests.js
+runTests.js.map

--- a/tests/runTests.ts
+++ b/tests/runTests.ts
@@ -3,8 +3,13 @@
 // * 'unpacked' will use ./testdir as test data; initialize this directory from testdir.tar with 'node extract.js' (note that regular untar will not work as it contains symlink loops)
 // * 'test000_0' specify a single test to run
 // * 'show-result' shows actual/expected for each test
+
+
 "use strict";
-var colors = require('colors');
+
+import { Options } from "..";
+
+var colors = require('colors/safe');
 var pathUtils = require('path');
 var shelljs = require('shelljs');
 var util = require('util');
@@ -25,6 +30,34 @@ var count = 0, failed = 0, successful = 0;
 var syncCount = 0, syncFailed = 0, syncSuccessful = 0;
 var asyncCount = 0, asyncFailed = 0, asyncSuccessful = 0;
 var cmdLineCount = 0, cmdLineFailed = 0, cmdLineSuccessful = 0;
+
+interface DisplayOptions {
+    showAll: boolean,
+    wholeReport: boolean,
+    nocolors: boolean,
+    csv: boolean,
+    noDiffIndicator: boolean
+}
+
+interface Test {
+    name: string,
+    path1: string,
+    path2: string,
+    description: string,
+    expected: string,
+    withRelativePath: boolean,
+    options: Partial<Options>,
+    commandLineOptions: string
+    exitCode: number,
+    displayOptions: Partial<DisplayOptions>,
+    print: any,
+    onlyLibrary: boolean,
+    onlyCommandLine: boolean,
+    skipStatisticsCheck: boolean,
+    onlySync: boolean,
+    nodeVersionSupport: boolean 
+}
+
 
 //Automatically track and cleanup files at exit
 temp.track();
@@ -65,7 +98,7 @@ function passed (value, type) {
         }
     }
 
-    return value ? 'Passed'.green : '!!!!FAILED!!!!'.yellow;
+    return value ? colors.green('Passed') : colors.yellow('!!!!FAILED!!!!');
 }
 
 /**
@@ -86,7 +119,7 @@ function passed (value, type) {
  * * nodeVersionSupport - limit test to specific node versions; ie. '>=2.5.0'
  */
 var getTests = function(testDirPath){
-    var res = [
+    var res : Partial<Test>[] = [
              {
                  name: 'test001_1', path1: 'd1', path2: 'd2',
                  options: {compareSize: true,},
@@ -505,6 +538,7 @@ var getTests = function(testDirPath){
                          statistics.test = 0;
                      }
                      statistics.test++;
+                     return undefined;
                  }},
                  displayOptions: {},
                  onlyLibrary: true,
@@ -520,6 +554,7 @@ var getTests = function(testDirPath){
                      }
                      statistics.test++;
                      diffSet.push(statistics.test);
+                     return undefined
                  }},
                  displayOptions: {},
                  onlyLibrary: true,
@@ -940,7 +975,7 @@ function executeTests (testDirPath, singleTestName, showResult) {
         return Promise.all(syncTestsPromises);
     }).then(function(){
         console.log();
-        console.log('Sync tests: ' + syncCount + ', failed: ' + syncFailed.toString().yellow + ', succeeded: ' + syncSuccessful.toString().green);
+        console.log('Sync tests: ' + syncCount + ', failed: ' + colors.yellow(syncFailed.toString()) + ', succeeded: ' + colors.green(syncSuccessful.toString()));
         console.log();
     }).then(function(){
         // Run async tests
@@ -955,7 +990,7 @@ function executeTests (testDirPath, singleTestName, showResult) {
         return Promise.all(asyncTestsPromises);
     }).then(function(){
         console.log();
-        console.log('Async tests: ' + asyncCount + ', failed: ' + asyncFailed.toString().yellow + ', succeeded: ' + asyncSuccessful.toString().green);
+        console.log('Async tests: ' + asyncCount + ', failed: ' + colors.yellow(asyncFailed.toString()) + ', succeeded: ' + colors.green(asyncSuccessful.toString()));
         console.log();
     }).then(function(){
         // Run command line tests
@@ -969,10 +1004,10 @@ function executeTests (testDirPath, singleTestName, showResult) {
         return Promise.all(commandLinePromises);
     }).then(function(){
         console.log();
-        console.log('Command line tests: ' + cmdLineCount + ', failed: ' + cmdLineFailed.toString().yellow + ', succeeded: ' + cmdLineSuccessful.toString().green);
+        console.log('Command line tests: ' + cmdLineCount + ', failed: ' + colors.yellow(cmdLineFailed.toString()) + ', succeeded: ' + colors.green(cmdLineSuccessful.toString()));
     }).then(function(){
         console.log();
-        console.log('All tests: ' + count + ', failed: ' + failed.toString().yellow + ', succeeded: ' + successful.toString().green);
+        console.log('All tests: ' + count + ', failed: ' + colors.yellow(failed.toString()) + ', succeeded: ' + colors.green(successful.toString()));
         endReport(saveReport);
         process.exitCode = failed>0?1:0
         process.chdir(__dirname);  // allow temp dir to be removed

--- a/tests/runTests.ts
+++ b/tests/runTests.ts
@@ -55,7 +55,7 @@ interface Test {
     onlyCommandLine: boolean,
     skipStatisticsCheck: boolean,
     onlySync: boolean,
-    nodeVersionSupport: boolean 
+    nodeVersionSupport: boolean
 }
 
 
@@ -523,7 +523,7 @@ var getTests = function(testDirPath){
              {
                  name: 'test008_3', path1: 'd1', path2: 'd2',
                  expected: 'total: 17, equal: 3, distinct: 0, only left: 7, only right: 7',
-                 options: null,
+                 options: {},
                  displayOptions: {wholeReport: true, nocolors: true, noDiffIndicator: true},
                  onlyLibrary: true,
              },
@@ -538,7 +538,6 @@ var getTests = function(testDirPath){
                          statistics.test = 0;
                      }
                      statistics.test++;
-                     return undefined;
                  }},
                  displayOptions: {},
                  onlyLibrary: true,
@@ -553,8 +552,9 @@ var getTests = function(testDirPath){
                          statistics.test = 0;
                      }
                      statistics.test++;
-                     diffSet.push(statistics.test);
-                     return undefined
+                     if(diffSet) {
+                        diffSet.push(statistics.test);
+                     }
                  }},
                  displayOptions: {},
                  onlyLibrary: true,
@@ -965,7 +965,7 @@ function executeTests (testDirPath, singleTestName, showResult) {
 	initReport(saveReport);
     Promise.resolve(getTests(testDirPath)).then(function(tests){
         // Run sync tests
-        var syncTestsPromises = [];
+        var syncTestsPromises: Promise<any>[] = [];
         tests.filter(function(test){return !test.onlyCommandLine;})
         .filter(function(test){return singleTestName?test.name===singleTestName:true;})
         .filter(function(test){return test.nodeVersionSupport===undefined || semver.satisfies(process.version, test.nodeVersionSupport) })
@@ -979,7 +979,7 @@ function executeTests (testDirPath, singleTestName, showResult) {
         console.log();
     }).then(function(){
         // Run async tests
-        var asyncTestsPromises = [];
+        var asyncTestsPromises: Promise<any>[] = [];
         getTests(testDirPath).filter(function(test){return !test.onlyCommandLine;})
         .filter(function(test){return !test.onlySync;})
         .filter(function(test){return test.nodeVersionSupport===undefined || semver.satisfies(process.version, test.nodeVersionSupport) })
@@ -994,7 +994,7 @@ function executeTests (testDirPath, singleTestName, showResult) {
         console.log();
     }).then(function(){
         // Run command line tests
-        var commandLinePromises = [];
+        var commandLinePromises: Promise<any>[] = [];
         getTests(testDirPath).filter(function(test){return !test.onlyLibrary;})
         .filter(function(test){return test.nodeVersionSupport===undefined || semver.satisfies(process.version, test.nodeVersionSupport) })
         .filter(function(test){return singleTestName?test.name===singleTestName:true;})
@@ -1017,7 +1017,7 @@ function executeTests (testDirPath, singleTestName, showResult) {
 
 var main = function () {
 	var args = process.argv;
-    var singleTestName = undefined, unpacked = false, showResult = false;
+    var singleTestName, unpacked = false, showResult = false;
     args.forEach(function(arg){
         if(arg.match('unpacked')) {
             unpacked = true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+      "target": "es5",
+      "module": "commonjs",
+      "sourceMap": true
+    },
+    "files": [
+      "./node_modules/@types/node/index.d.ts",
+      "./index.d.ts"
+    ],
+    "include": [
+      "tests/*.ts",
+      "*.ts"
+    ],
+    "exclude": [
+      "node_modules"
+    ]
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
       "target": "es5",
       "module": "commonjs",
-      "sourceMap": true
+      "sourceMap": true,
+      "strictNullChecks": true
     },
     "files": [
       "./node_modules/@types/node/index.d.ts",


### PR DESCRIPTION
Resolves #11

Thanks again for the great library.

I've added type definitions and copied over the comments from the documentation so that they show up in intellisense etc.

Because dir-compare sometimes exposes `fs.Stat` (e.g. to callbacks) I've had to add a dependency on the node typings `types/node` in `package.json`.

Thanks again for the library :) If it is of any interest to you - I am using it in my [barrelsby project](https://github.com/bencoveney/barrelsby/blob/master/test/src.ts) to integration test the output of the CLI tool.